### PR TITLE
feat: allow templating

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -1,0 +1,168 @@
+name: Test Template
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  test-template-ios:
+    name: Template → iOS Build
+    runs-on: macos-15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache: false
+
+      - name: Generate project from template
+        run: |
+          cd cli
+          bash build-template.sh
+          node bin.js test-app --bundleId com.ci.testapp --goModule ci.test/test-app
+
+      - name: Verify no leftover identifiers
+        run: |
+          cd cli/test-app
+          if grep -r "rn-golang" --include="*.go" --include="*.ts" --include="*.json" --include="*.kt" --include="*.swift" --include="*.pbxproj" --include="*.plist" .; then
+            echo "ERROR: Found leftover 'rn-golang' references"
+            exit 1
+          fi
+          if grep -r "io.rngolang.app" .; then
+            echo "ERROR: Found leftover 'io.rngolang.app' references"
+            exit 1
+          fi
+          if grep -r "siddarthkay/react-native-go" .; then
+            echo "ERROR: Found leftover Go module references"
+            exit 1
+          fi
+          echo "All identifiers replaced correctly"
+
+      - name: Setup Go backend
+        run: make -C cli/test-app/backend setup
+
+      - name: Build Go backend for iOS
+        run: make -C cli/test-app/backend ios
+
+      - name: Install Node dependencies
+        run: make -C cli/test-app/mobile-app install
+        env:
+          YARN_ENABLE_HARDENED_MODE: 0
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.0'
+          working-directory: cli/test-app/mobile-app/ios
+
+      - name: Install CocoaPods
+        run: make -C cli/test-app/mobile-app pod-install
+
+      - name: Select Xcode
+        run: sudo xcode-select -s "/Applications/Xcode_16.4.app/Contents/Developer"
+
+      - name: Build iOS Simulator App
+        working-directory: cli/test-app/mobile-app
+        run: |
+          set -o pipefail
+          xcodebuild -workspace ios/testapp.xcworkspace \
+            -scheme testapp \
+            -sdk iphonesimulator \
+            -configuration Release \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -derivedDataPath ios/build \
+            CODE_SIGNING_ALLOWED=NO \
+            ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=YES
+
+  test-template-android:
+    name: Template → Android Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache: false
+
+      - name: Generate project from template
+        run: |
+          cd cli
+          bash build-template.sh
+          node bin.js test-app --bundleId com.ci.testapp --goModule ci.test/test-app
+
+      - name: Verify no leftover identifiers
+        run: |
+          cd cli/test-app
+          if grep -r "rn-golang" --include="*.go" --include="*.ts" --include="*.json" --include="*.kt" --include="*.swift" --include="*.pbxproj" --include="*.plist" .; then
+            echo "ERROR: Found leftover 'rn-golang' references"
+            exit 1
+          fi
+          if grep -r "io.rngolang.app" .; then
+            echo "ERROR: Found leftover 'io.rngolang.app' references"
+            exit 1
+          fi
+          if grep -r "siddarthkay/react-native-go" .; then
+            echo "ERROR: Found leftover Go module references"
+            exit 1
+          fi
+          echo "All identifiers replaced correctly"
+
+      - name: Setup Go backend
+        run: make -C cli/test-app/backend setup
+
+      - name: Build Go backend for Android
+        run: make -C cli/test-app/backend android
+
+      - name: Install Node dependencies
+        run: make -C cli/test-app/mobile-app install
+        env:
+          YARN_ENABLE_HARDENED_MODE: 0
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'zulu'
+
+      - name: Setup Gradle cache
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          cache-read-only: false
+
+      - name: Build Release APK
+        run: make -C cli/test-app/mobile-app build-android
+
+      - name: Stop Gradle daemon
+        if: always()
+        working-directory: cli/test-app/mobile-app/android
+        run: ./gradlew --stop

--- a/.gitignore
+++ b/.gitignore
@@ -60,9 +60,13 @@ backend/*.xcframework
 # IDEs
 .vscode/
 .idea/
+.claude/
 *.swp
 *.swo
 *~
+
+# CLI template (generated before npm publish)
+cli/template/
 
 # Testing
 coverage/

--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ This project showcases how to build a fast mobile application where:
 - iOS: Xcode 15+, CocoaPods
 - Android: Android Studio, JDK 17+
 
+## Create a New Project
+
+```bash
+npx create-react-native-go my-app --bundleId com.mycompany.myapp --goModule mycompany.com/my-app
+cd my-app
+make setup
+make ios    # or: make android
+```
+
+The CLI scaffolds a new project with your app name, bundle ID, and Go module — fully configured and ready to build.
+
 ## Quick Start
 
 ### Setup

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,62 @@
+# create-react-native-go
+
+Scaffold a React Native + Go mobile app in seconds. Go runs as an embedded HTTP server providing JSON-RPC APIs, while React Native handles the UI with the New Architecture (Fabric + TurboModules).
+
+## Usage
+
+```bash
+npx create-react-native-go my-app --bundleId com.mycompany.myapp --goModule mycompany.com/my-app
+cd my-app
+make setup
+make ios    # or: make android
+```
+
+If you omit any flags, the CLI will prompt you interactively.
+
+## What You Get
+
+```
+my-app/
+├── Makefile                        # Root orchestrator
+├── backend/
+│   ├── Makefile                    # Go build targets
+│   ├── mobile_api.go               # Mobile API for server lifecycle
+│   └── http_server.go              # JSON-RPC HTTP server
+└── mobile-app/
+    ├── Makefile                    # Mobile build targets
+    ├── src/
+    │   ├── NativeGoServerBridge.ts # TurboModule spec
+    │   ├── GoServerBridgeJSI.ts    # JSI wrapper
+    │   └── JsonRpcClient.ts        # JSON-RPC client
+    ├── android/                    # Android native code
+    └── ios/                        # iOS native code
+```
+
+## Prerequisites
+
+- Node.js 18+
+- Go 1.25+
+- iOS: Xcode 15+, CocoaPods
+- Android: Android Studio, JDK 17+
+
+## Options
+
+| Flag | Description | Example |
+|------|-------------|---------|
+| `--bundleId` | App bundle identifier | `com.mycompany.myapp` |
+| `--goModule` | Go module path | `mycompany.com/my-app` |
+
+The first positional argument is the app name (e.g. `my-app`).
+
+## How It Works
+
+The CLI copies a pre-built template and replaces all identifiers (app name, bundle ID, Go module path, iOS project name, Android package directories) to match your configuration. It then initializes a fresh git repo.
+
+## Links
+
+- [GitHub Repository](https://github.com/siddarthkay/react-native-go)
+- [Issues](https://github.com/siddarthkay/react-native-go/issues)
+
+## License
+
+MIT

--- a/cli/bin.js
+++ b/cli/bin.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+const { run } = require("./src/index");
+run();

--- a/cli/build-template.sh
+++ b/cli/build-template.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Copies project template files into cli/template/ for npm publishing.
+# Run this before `npm publish` in the cli/ directory.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+TEMPLATE_DIR="$SCRIPT_DIR/template"
+
+echo "Building template from repo..."
+
+rm -rf "$TEMPLATE_DIR"
+mkdir -p "$TEMPLATE_DIR"
+
+# Use rsync to copy while excluding build artifacts and dependencies
+rsync -a \
+  --exclude='.git' \
+  --exclude='node_modules' \
+  --exclude='Pods' \
+  --exclude='Podfile.lock' \
+  --exclude='*.xcworkspace' \
+  --exclude='build' \
+  --exclude='.gradle' \
+  --exclude='gradle/' \
+  --exclude='.yarn/cache' \
+  --exclude='.yarn/install-state.gz' \
+  --exclude='gobridge.aar' \
+  --exclude='Gobridge.xcframework' \
+  --exclude='go.sum' \
+  --exclude='.expo' \
+  --exclude='.cxx' \
+  --exclude='local.properties' \
+  "$REPO_ROOT/backend" "$TEMPLATE_DIR/"
+
+rsync -a \
+  --exclude='.git' \
+  --exclude='node_modules' \
+  --exclude='Pods' \
+  --exclude='Podfile.lock' \
+  --exclude='*.xcworkspace' \
+  --exclude='build' \
+  --exclude='.gradle' \
+  --exclude='.yarn/cache' \
+  --exclude='.yarn/install-state.gz' \
+  --exclude='gobridge.aar' \
+  --exclude='Gobridge.xcframework' \
+  --exclude='.expo' \
+  --exclude='.cxx' \
+  --exclude='.claude' \
+  --exclude='local.properties' \
+  "$REPO_ROOT/mobile-app" "$TEMPLATE_DIR/"
+
+cp "$REPO_ROOT/Makefile" "$TEMPLATE_DIR/Makefile"
+cp "$REPO_ROOT/.gitignore" "$TEMPLATE_DIR/.gitignore"
+
+echo "Template built at: $TEMPLATE_DIR"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "create-react-native-go",
+  "version": "1.0.2",
+  "description": "Create a React Native + Go mobile app",
+  "bin": {
+    "create-react-native-go": "./bin.js"
+  },
+  "scripts": {
+    "prepublishOnly": "./build-template.sh"
+  },
+  "files": [
+    "bin.js",
+    "src/",
+    "template/"
+  ],
+  "keywords": [
+    "react-native",
+    "golang",
+    "go",
+    "mobile",
+    "template",
+    "gomobile",
+    "jsi",
+    "turbomodules"
+  ],
+  "author": "siddarthkay",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/siddarthkay/react-native-go"
+  }
+}

--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -1,0 +1,326 @@
+const fs = require("fs");
+const path = require("path");
+const readline = require("readline");
+const { execSync } = require("child_process");
+
+const TEMPLATE_DIR = path.join(__dirname, "..", "template");
+
+const OLD_APP_NAME = "rn-golang";
+const OLD_BUNDLE_ID = "io.rngolang.app";
+const OLD_GO_MODULE = "github.com/siddarthkay/react-native-go";
+const OLD_IOS_PROJECT = "mobileapp";
+const OLD_ANDROID_ROOT_PROJECT = "mobile-app";
+
+const SKIP_DIRS = new Set([
+  ".git",
+  "node_modules",
+  "Pods",
+  "build",
+  ".yarn",
+  "Frameworks",
+  "libs",
+  ".expo",
+]);
+
+const SKIP_EXTENSIONS = new Set([
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".gif",
+  ".ico",
+  ".jar",
+  ".aar",
+  ".xcframework",
+]);
+
+function ask(question) {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+function validateBundleId(id) {
+  return /^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*)+$/.test(id);
+}
+
+function deriveIosProject(appName) {
+  return appName.replace(/-/g, "").toLowerCase();
+}
+
+function copyDir(src, dest) {
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      copyDir(srcPath, destPath);
+    } else {
+      if (SKIP_EXTENSIONS.has(path.extname(entry.name))) {
+        fs.copyFileSync(srcPath, destPath);
+      } else {
+        fs.copyFileSync(srcPath, destPath);
+      }
+    }
+  }
+}
+
+function replaceInFile(filePath, replacements) {
+  let content;
+  try {
+    content = fs.readFileSync(filePath, "utf8");
+  } catch {
+    return false;
+  }
+
+  // Check if binary
+  if (content.includes("\0")) return false;
+
+  let changed = false;
+  for (const [old, replacement] of replacements) {
+    if (content.includes(old)) {
+      content = content.split(old).join(replacement);
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    fs.writeFileSync(filePath, content, "utf8");
+  }
+  return changed;
+}
+
+function walkFiles(dir) {
+  const results = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      results.push(...walkFiles(fullPath));
+    } else {
+      if (!SKIP_EXTENSIONS.has(path.extname(entry.name))) {
+        results.push(fullPath);
+      }
+    }
+  }
+  return results;
+}
+
+function renameAndMoveAndroidPackage(projectDir, oldBundleId, newBundleId) {
+  const javaDir = path.join(
+    projectDir,
+    "mobile-app",
+    "android",
+    "app",
+    "src",
+    "main",
+    "java"
+  );
+  const oldPkgDir = path.join(javaDir, ...oldBundleId.split("."));
+  const newPkgDir = path.join(javaDir, ...newBundleId.split("."));
+
+  if (!fs.existsSync(oldPkgDir)) return;
+
+  fs.mkdirSync(newPkgDir, { recursive: true });
+
+  for (const file of fs.readdirSync(oldPkgDir)) {
+    fs.renameSync(path.join(oldPkgDir, file), path.join(newPkgDir, file));
+  }
+
+  // Remove old empty directories
+  const oldTopDir = path.join(javaDir, oldBundleId.split(".")[0]);
+  const newTopDir = path.join(javaDir, newBundleId.split(".")[0]);
+  if (oldTopDir !== newTopDir) {
+    fs.rmSync(oldTopDir, { recursive: true, force: true });
+  } else {
+    // Clean up empty dirs
+    let dir = oldPkgDir;
+    while (dir !== javaDir) {
+      try {
+        fs.rmdirSync(dir);
+      } catch {
+        break;
+      }
+      dir = path.dirname(dir);
+    }
+  }
+}
+
+function renameIosProject(projectDir, oldName, newName) {
+  const iosDir = path.join(projectDir, "mobile-app", "ios");
+
+  const renames = [
+    [oldName, newName],
+    [`${oldName}.xcodeproj`, `${newName}.xcodeproj`],
+    [`${oldName}.xcworkspace`, `${newName}.xcworkspace`],
+  ];
+
+  for (const [oldDir, newDir] of renames) {
+    const oldPath = path.join(iosDir, oldDir);
+    const newPath = path.join(iosDir, newDir);
+    if (fs.existsSync(oldPath)) {
+      fs.renameSync(oldPath, newPath);
+    }
+  }
+
+  // Rename files inside the iOS project directory
+  const newProjectDir = path.join(iosDir, newName);
+  if (fs.existsSync(newProjectDir)) {
+    for (const file of fs.readdirSync(newProjectDir)) {
+      if (file.includes(oldName)) {
+        const newFile = file.split(oldName).join(newName);
+        fs.renameSync(
+          path.join(newProjectDir, file),
+          path.join(newProjectDir, newFile)
+        );
+      }
+    }
+  }
+
+  // Rename scheme file inside .xcodeproj
+  const schemesDir = path.join(
+    iosDir,
+    `${newName}.xcodeproj`,
+    "xcshareddata",
+    "xcschemes"
+  );
+  if (fs.existsSync(schemesDir)) {
+    for (const file of fs.readdirSync(schemesDir)) {
+      if (file.includes(oldName)) {
+        const newFile = file.split(oldName).join(newName);
+        fs.renameSync(
+          path.join(schemesDir, file),
+          path.join(schemesDir, newFile)
+        );
+      }
+    }
+  }
+}
+
+async function run() {
+  const args = process.argv.slice(2);
+  let appName = args[0];
+  let bundleId = null;
+  let goModule = null;
+
+  // Parse flags
+  for (let i = 1; i < args.length; i++) {
+    if (args[i] === "--bundleId" && args[i + 1]) {
+      bundleId = args[++i];
+    } else if (args[i] === "--goModule" && args[i + 1]) {
+      goModule = args[++i];
+    }
+  }
+
+  console.log("");
+  console.log("\x1b[36m=== create-react-native-go ===\x1b[0m");
+  console.log("");
+
+  if (!appName) {
+    appName = await ask("App name (e.g. my-app): ");
+  }
+  if (!appName) {
+    console.error("\x1b[31mApp name is required.\x1b[0m");
+    process.exit(1);
+  }
+
+  if (!bundleId) {
+    bundleId = await ask("Bundle ID (e.g. com.mycompany.myapp): ");
+  }
+  if (!bundleId) {
+    console.error("\x1b[31mBundle ID is required.\x1b[0m");
+    process.exit(1);
+  }
+  if (!validateBundleId(bundleId)) {
+    console.error(
+      "\x1b[31mInvalid bundle ID. Use lowercase like: com.company.appname\x1b[0m"
+    );
+    process.exit(1);
+  }
+
+  if (!goModule) {
+    goModule = await ask("Go module path (e.g. mycompany.com/my-app): ");
+  }
+  if (!goModule) {
+    console.error("\x1b[31mGo module path is required.\x1b[0m");
+    process.exit(1);
+  }
+
+  const iosProject = deriveIosProject(appName);
+  const projectDir = path.resolve(fs.realpathSync(process.cwd()), appName);
+
+  console.log("");
+  console.log(`  App name:     ${appName}`);
+  console.log(`  Bundle ID:    ${bundleId}`);
+  console.log(`  Go module:    ${goModule}`);
+  console.log(`  iOS project:  ${iosProject}`);
+  console.log(`  Directory:    ${projectDir}`);
+  console.log("");
+
+  if (fs.existsSync(projectDir)) {
+    console.error(`\x1b[31mDirectory "${appName}" already exists.\x1b[0m`);
+    process.exit(1);
+  }
+
+  // Step 1: Copy template
+  console.log("\x1b[36mCopying template...\x1b[0m");
+  copyDir(TEMPLATE_DIR, projectDir);
+
+  // Step 2: Replace identifiers in all files
+  console.log("\x1b[36mConfiguring project...\x1b[0m");
+
+  const replacements = [
+    [OLD_GO_MODULE, goModule],
+    [OLD_BUNDLE_ID, bundleId],
+    [OLD_APP_NAME, appName],
+    [`rootProject.name = '${OLD_ANDROID_ROOT_PROJECT}'`, `rootProject.name = '${appName}'`],
+    [OLD_IOS_PROJECT, iosProject],
+  ];
+
+  const files = walkFiles(projectDir);
+  let updatedCount = 0;
+  for (const file of files) {
+    if (replaceInFile(file, replacements)) {
+      updatedCount++;
+    }
+  }
+  console.log(`  Updated ${updatedCount} files`);
+
+  // Step 3: Rename Android package directories
+  console.log("\x1b[36mRestructuring Android packages...\x1b[0m");
+  renameAndMoveAndroidPackage(projectDir, OLD_BUNDLE_ID, bundleId);
+
+  // Step 4: Rename iOS project
+  console.log("\x1b[36mRenaming iOS project...\x1b[0m");
+  renameIosProject(projectDir, OLD_IOS_PROJECT, iosProject);
+
+  // Step 5: Initialize git
+  console.log("\x1b[36mInitializing git...\x1b[0m");
+  try {
+    execSync("git init", { cwd: projectDir, stdio: "ignore" });
+    execSync("git add -A", { cwd: projectDir, stdio: "ignore" });
+    execSync('git commit -m "Initial commit from create-react-native-go"', {
+      cwd: projectDir,
+      stdio: "ignore",
+    });
+  } catch {
+    // git init is nice-to-have, not critical
+  }
+
+  console.log("");
+  console.log("\x1b[32m=== Project created! ===\x1b[0m");
+  console.log("");
+  console.log(`  cd ${appName}`);
+  console.log("  make setup");
+  console.log("  make ios    # or: make android");
+  console.log("");
+}
+
+module.exports = { run };

--- a/mobile-app/ios/.xcode.env
+++ b/mobile-app/ios/.xcode.env
@@ -9,3 +9,8 @@
 # For example, to use nvm with brew, add the following line
 # . "$(brew --prefix nvm)/nvm.sh" --no-use
 export NODE_BINARY=$(command -v node)
+
+# Resolve symlinks in PROJECT_DIR (fixes /tmp → /private/tmp on macOS)
+if [ -n "$PROJECT_DIR" ]; then
+  PROJECT_DIR=$(cd "$PROJECT_DIR" && pwd -P)
+fi


### PR DESCRIPTION
## Summary
- introduces https://www.npmjs.com/package/create-react-native-go cli util to generate a templated react-native app with go.
- fix an issue where running mobile-app used to fail from `/tmp` on macos.
